### PR TITLE
Fix link to stub loader full error code list (documentation only)

### DIFF
--- a/docs/en/advanced-topics/serial-protocol.rst
+++ b/docs/en/advanced-topics/serial-protocol.rst
@@ -144,7 +144,7 @@ Stub Loader Status & Error
 If the stub loader is used:
 
 -  The status response is always 2 bytes regardless of chip type.
--  Stub loader error codes are entirely different to the ROM loader codes. They all take the form ``0xC*``, or ``0xFF`` for "unimplemented command". (`Full list here <https://github.com/espressif/esptool/blob/master/flasher_stub/include/stub_flasher.h#L95>`_).
+-  Stub loader error codes are entirely different to the ROM loader codes. They all take the form ``0xC*``, or ``0xFF`` for "unimplemented command". (`Full list here <https://github.com/espressif/esptool-legacy-flasher-stub/blob/18462389a024fc1520c85aa161cf4877b68f83f5/flasher_stub/include/stub_flasher.h#L95>`_).
 
 After sending a command, the host should continue to read response packets until one is received where the Command field matches the request's Command field, or a timeout is exceeded.
 


### PR DESCRIPTION
The `Full List here`  link in the Serial Protocol documentation file refers to an outdated repository which does not exist any more (=> 404).

<img width="1129" height="281" alt="image" src="https://github.com/user-attachments/assets/957a72f5-402c-452c-b5a9-c4b404c3a877" />

This MR replaces it by this link:
https://github.com/espressif/esptool-legacy-flasher-stub/blob/master/flasher_stub/include/stub_flasher.h#L95


# This change fixes the following bug(s):
None

# I have tested this change with the following hardware & software combinations:

NO TESTING

# I have run the esptool automated integration tests with this change and the above hardware:

NO TESTING
